### PR TITLE
Use root and set work dir

### DIFF
--- a/apko.yaml
+++ b/apko.yaml
@@ -6,14 +6,6 @@ contents:
     - alpine-baselayout-data
     - gcc
     - musl-dev
-accounts:
-  groups:
-    - groupname: nonroot
-      gid: 65532
-  users:
-    - username: nonroot
-      uid: 65532
-  run-as: 65532
 entrypoint:
   command: /usr/bin/gcc
 cmd: --help

--- a/apko.yaml
+++ b/apko.yaml
@@ -6,6 +6,14 @@ contents:
     - alpine-baselayout-data
     - gcc
     - musl-dev
+
+paths:
+  - path: /work
+    type: directory
+    permissions: 0o777
+
+work-dir: /work
+
 entrypoint:
   command: /usr/bin/gcc
 cmd: --help


### PR DESCRIPTION
There was a user set in the image, which is normally a good thing, but for a builder image I think it should be root.

For example, to use the current image in a Dockerfile I had to do the following:

```
ARG BASE=distroless.dev/musl-dynamic

FROM distroless.dev/musl-build as build

COPY hello.c /home/nonroot/hello.c
RUN ["cc", "/home/nonroot/hello.c", "-o", "/home/nonroot/hello"]
```

If root is used, we don't need to worry about the compilation and output directory.

Also, I set a workdir to /work as a convenience.