### PR TITLE
Add busybox.

### DIFF
--- a/apko.yaml
+++ b/apko.yaml
@@ -6,6 +6,7 @@ contents:
     - alpine-baselayout-data
     - gcc
     - musl-dev
+    - busybox
 
 paths:
   - path: /work


### PR DESCRIPTION
Builder images should have a shell.

Signed-off-by: Adrian Mouat <adrian@chainguard.dev>